### PR TITLE
Fix for Sign in 

### DIFF
--- a/custom-controller/app/controllers/sessions_controller.rb
+++ b/custom-controller/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
   def sign_in
     message = Siwe::Message.from_json_string session[:message]
 
-    if message.validate(params.require(:signature))
+    if message.verify(params.require(:signature), message.domain, message.issued_at, message.nonce)
       session[:message] = nil
       session[:ens] = params[:ens]
       session[:address] = message.address


### PR DESCRIPTION
Unless there's something I'm missing, the examples are broken.
At the moment, when clicking the sign in button, the Metamask pop up requesting the signature will prompt to sign, but then the request is met with a 500 error, being the line in `sessions_controller.rb` `if message.validate(params.require(:signature))` the culprit. Error says the function is expecting 0 arguments and 1 was supplied.

Having gone through the more maintained typescript examples, the function that this should be invoking would be message.verify which expects 4 arguments. 

The proposed change fixes that and the custom-controller example now works as expected, though not sure if more validations would be required.
